### PR TITLE
Only run handlebars.compile once

### DIFF
--- a/static.js
+++ b/static.js
@@ -11,22 +11,22 @@ function generateFile(slug, content) {
 }
 
 function generateStatic() {
-  const indexContent = fs
+  const indexContent = handlebars.compile(fs
     .readFileSync(`${notionCfg.app.viewsDirectory}/index.hbs`, "utf-8")
-    .toString();
-  const pageContent = fs
+    .toString());
+  const pageContent = handlebars.compile(fs
     .readFileSync(`${notionCfg.app.viewsDirectory}/page.hbs`, "utf-8")
-    .toString();
-  const redirectContent = fs
+    .toString());
+  const redirectContent = handlebars.compile(fs
     .readFileSync(`${notionCfg.app.viewsDirectory}/redirect.hbs`, "utf-8")
-    .toString();
+    .toString());
 
-  const pages = {...SITE_DATA};
+  const pages = { ...SITE_DATA };
   delete pages['index'];
 
   generateFile(
     "index",
-    handlebars.compile(indexContent)({
+    indexContent({
       layout: false,
       title: notionCfg.app.name,
       pages: pages,
@@ -39,7 +39,7 @@ function generateStatic() {
       if (notionCfg.notion.linkOriginalPage) {
         generateFile(
           "page",
-          handlebars.compile(redirectContent)({ pageUrl: page.pageUrl })
+          redirectContent({ pageUrl: page.pageUrl })
         );
       }
       continue;
@@ -47,7 +47,7 @@ function generateStatic() {
 
     generateFile(
       page.slug,
-      handlebars.compile(pageContent)({
+      pageContent({
         layout: false,
         title: notionCfg.app.name,
         ...page,
@@ -61,7 +61,7 @@ function generateStatic() {
       }
       generateFile(
         `${page.slug}/page`,
-        handlebars.compile(redirectContent)({ pageUrl: page.pageUrl })
+        redirectContent({ pageUrl: page.pageUrl })
       );
     }
   }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -20,7 +20,7 @@
 <body>
   <div class="container">
     <h1 class="pt-8">{{title}}</h1>
-    {{{content}}}
+    {{{content.html}}}
   </div>
 </body>
 

--- a/views/page.hbs
+++ b/views/page.hbs
@@ -17,7 +17,7 @@
 </head>
 
 <body>
-  {{{content}}}
+  {{{content.html}}}
 </body>
 
 </html>

--- a/views/partials/callout.hbs
+++ b/views/partials/callout.hbs
@@ -1,5 +1,5 @@
 <div class="callout">
     <div class="container">
-        {{{content}}}
+        {{{content.html}}}
     </div>
 </div>

--- a/views/redirect.hbs
+++ b/views/redirect.hbs
@@ -7,6 +7,12 @@
 
 <body>
     <em>Redirecting...</em>
+    <!-- Some users may have automatic redirect disabled -->
+    <p>
+        Please click
+        <a href="{{pageUrl}}">here</a>
+        if you do not get redirected automatically
+    </p>
 </body>
 
 </html>


### PR DESCRIPTION
Since the layout does not change, we do not need to recompile and can exclude this action for faster generation cycles. This PR also addresses the issue where [object Object] gets displayed instead of the page's content, which is caused by the layout not using the .html property of the content object.